### PR TITLE
Topページ機能追加

### DIFF
--- a/app/controllers/admin/customers_controller.rb
+++ b/app/controllers/admin/customers_controller.rb
@@ -5,12 +5,28 @@ class Admin::CustomersController < ApplicationController
 
   def show
     @public = Public.find(params[:id])
-    #@publics = Public.all
   end
 
   def edit
+    @public = Public.find(params[:id])
   end
 
   def update
+    @public = Public.find(params[:id])
+    if @public.update(public_params)
+      redirect_to admin_customer_path(@public.id)
+      flash[:notice] = '会員情報が更新されました。'
+    else
+      render :edit
+    end
+  end
+
+  private
+
+  def public_params
+    params.require(:public).permit(
+      :family_name, :first_name, :family_name_kana,
+      :first_name_kana, :postal_code, :address,
+      :phone_number, :email, :is_deleted)
   end
 end

--- a/app/controllers/admin/homes_controller.rb
+++ b/app/controllers/admin/homes_controller.rb
@@ -1,4 +1,5 @@
 class Admin::HomesController < ApplicationController
-  def topページ
+  def top
+    @orders = Order.all
   end
 end

--- a/app/controllers/admin/orders_controller.rb
+++ b/app/controllers/admin/orders_controller.rb
@@ -1,5 +1,6 @@
 class Admin::OrdersController < ApplicationController
   def show
+    #@orders = Order.all
   end
 
   def updated

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,8 +4,7 @@ class ApplicationController < ActionController::Base
     when Admin
       admin_root_path    # ログイン後に遷移するpathを設定
     when Public
-      #root_path # ログイン後に遷移するpathを設定
-      root_path
+      root_path # ログイン後に遷移するpathを設定
     end
   end
 

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,2 +1,7 @@
 class Address < ApplicationRecord
+  validates :postal_code, length: {minimum:7, maximum:7}
+  vaildates :address, presence: true
+  vaildates :name, presence: true, length: {maximum:50}
+
+  belongs_to :public, optional: true
 end

--- a/app/models/cart_item.rb
+++ b/app/models/cart_item.rb
@@ -1,2 +1,4 @@
 class CartItem < ApplicationRecord
+  belongs_to :public, optional: true
+  belongs_to :item, optional: true
 end

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,2 +1,5 @@
 class Genre < ApplicationRecord
+  vaildates :name, presence: true, length: {maximum:20}
+
+  belongs_to :item, optional: true
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,3 +1,12 @@
 class Item < ApplicationRecord
+  vaildates :genre_id, presence: true
+  vaildates :name, presence: true, length: {maximum:100}
+  vaildates :explanation, presence: true, length: {maximum:999}
+  vaildates :price, presence: true
+  vaildates :is_stock, presence: true
+
   has_one_attached :image
+  has_many :cart_items, dependent: :destroy
+  has_many :order_details
+  has_one :genre
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,2 +1,12 @@
 class Order < ApplicationRecord
+  validates :postal_code, length: {minimum:7, maximum:7}
+  vaildates :delivery_address, presence: true, length: {maximum:300}
+  vaildates :delivery_name, presence: true, length: {maximum:50}
+  vaildates :method_of_payment, presence: true
+  vaildates :status, presence: true
+  vaildates :total_price, presence: true
+  vaildates :delivery_charge, presence: true
+
+  belongs_to :public, optional: true
+  has_many :order_details, dependent: :destroy
 end

--- a/app/models/order_detail.rb
+++ b/app/models/order_detail.rb
@@ -1,2 +1,7 @@
 class OrderDetail < ApplicationRecord
+  vaildates :quantity, presence: true
+  vaildates :making_status, presence: true
+
+  belongs_to :order, optional: true
+  belongs_to :item, optional: true
 end

--- a/app/models/public.rb
+++ b/app/models/public.rb
@@ -3,4 +3,8 @@ class Public < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+  has_many :cart_items, dependent: :destroy
+  has_many :addresses, dependent: :destroy
+  has_many :orders, dependent: :destroy
 end

--- a/app/views/admin/customers/edit.html.erb
+++ b/app/views/admin/customers/edit.html.erb
@@ -1,21 +1,43 @@
 <h1>Admin::Customers#edit</h1>
 <p>Find me in app/views/admin/customers/edit.html.erb</p>
+<%# form_withを使い、情報を取得するモデル、rails routesで調べたURL、メソッドを指定して、'f.text_field'でデータを引っ張ってきてください。%>
+<%= form_with model: @public, url: admin_customer_path(@public.id), local:true, method: :patch do |f| %>
+<table>
+    <thead>
+      <tr><b><%= @public.family_name+@public.first_name %>さんの会員情報編集</b></tr>
+    </thead>
+      <tbody>
+      <tr><td>会員ID</td><td><%= @public.id %></td></tr>
 
-<div class="container takasa">
-  <div class="row">
+      <tr><td>氏名</td><td> <%= f.text_field :family_name %>   <%= f.text_field :first_name %></td></tr>
 
-    <div class="col-xs-9">
-      <h2>ジャンル編集</h2><br>
+      <tr><td>フリガナ</td><td><%= f.text_field :family_name_kana %>   <%= f.text_field :first_name_kana %></td></tr>
 
-       <%= form_for @genre, url: admin_genre_path(@genre.id) do |f| %>
-        <div class="field row">
-          <lavel>ジャンル</lavel>
-          <%= f.text_field :name %>
-  
-          <label><%= f.radio_button :valid_invalid_status, "有効" %> 有効 </label>
-          <label><%= f.radio_button :valid_invalid_status, "無効" %> 無効</label>
-          <%= f.submit "変更を保存する", class: "btn btn-primary" %>
-         </div>
-      <% end %>
-  </div>
-</div>
+      <tr><td>郵便番号</td><td><%= f.text_field :postal_code %></td></tr>
+
+      <tr><td>住所</td><td><%= f.text_area :address %></td></tr>
+
+      <tr><td>電話番号</td><td><%= f.text_field :phone_number %></td></tr>
+
+      <tr><td>メールアドレス</td><td><%= f.text_field :email %></td></tr>
+
+      <tr><td>会員ステータス</td><td>
+        <%# is_deleted(退会フラグ)がfalse(初期値)なら'有効' %>
+        <%= f.radio_button :is_deleted, :false %>
+        <%= f.label :is_deleted, "有効" %>
+        <%# is_deleted(退会フラグ)がtrue(退会処理済み)なら'退会' %>
+        <%= f.radio_button :is_deleted, :true %>
+        <%= f.label :is_deleted, "退会" %>
+      </td><td>
+        <%= f.submit '変更を保存' %>
+      </td></tr>
+    </tbody>
+
+
+  </table>
+  <% end %>
+
+
+
+
+

--- a/app/views/admin/customers/index.html.erb
+++ b/app/views/admin/customers/index.html.erb
@@ -12,29 +12,23 @@
         <th colspan="5"></th><br>
       </tr>
     </thead>
-      <% @publics.each do |public| %>
+      <% @publics.each do |public| %><%# @publics = Public.allですべてのPublicユーザーの情報を取得して、順番に並べて表示 %>
     <tbody>
       <tr>
+      <td><%= public.id %></td>
 
       <td>
-        <%= public.id %>
+        <%# A+Bと表記して、二つの表示をくっつけてABと表示できます。%>
+        <%= link_to public.family_name+public.first_name, admin_customer_path(public.id) %>
       </td>
 
-      <td>
-        <%= link_to public.family_name+public.first_name, admin_customers_path(public.id) %>
-        <%#= public.family_name+public.first_name %>
-        <%#= public.family_name %><%#= public.first_name %>
-      </td>
+      <td><%= public.email %></td>
 
       <td>
-        <%= public.email %>
-      </td>
-
-      <td>
-        <% if public.is_deleted %>
-        退会
+        <% if public.is_deleted %><%# is_deletedの情報を取得して退会済みかチェック %>
+        退会  <%# true(退会済み)の時の表示 %>
         <% else %>
-        有効
+        有効  <%# false(初期値)の時の表示 %>
         <% end %>
       </td>
       </tr>

--- a/app/views/admin/customers/show.html.erb
+++ b/app/views/admin/customers/show.html.erb
@@ -1,51 +1,33 @@
 <h1>Admin::Customers#show</h1>
 <p>Find me in app/views/admin/customers/show.html.erb</p>
-
+<%# @public = Public.find(params[:id])を使い、指定したPublicユーザーの情報を取得してひたすら表示するだけ %>
 <table>
     <thead>
-      <tr><b><%= @public.family_name+@public.first_name %>さんの会員詳細</b>
-      </tr>
+      <tr><b><%= @public.family_name+@public.first_name %>さんの会員詳細</b></tr>
     </thead>
       <tbody>
-      <tr>
-      <td>会員ID</td><td><%= @public.id %></td>
-      </tr>
+      <tr><td>会員ID</td><td><%= @public.id %></td></tr>
 
-      <tr>
-      <td>氏名</td><td><%= @public.family_name %>  <%= @public.first_name %></td>
-      </tr>
+      <tr><td>氏名</td><td><%= @public.family_name %>  <%= @public.first_name %></td></tr>
 
-      <tr>
-      <td>フリガナ</td><td><%= @public.family_name_kana %>  <%= @public.first_name_kana %></td>
-      </tr>
+      <tr><td>フリガナ</td><td><%= @public.family_name_kana %>  <%= @public.first_name_kana %></td></tr>
 
-      <tr>
-      <td>郵便番号</td><td><%= @public.postal_code %></td>
-      </tr>
+      <tr><td>郵便番号</td><td><%= @public.postal_code %></td></tr>
 
-      <tr>
-      <td>住所</td><td><%= @public.address %></td>
-      </tr>
+      <tr><td>住所</td><td><%= @public.address %></td></tr>
 
-      <tr>
-      <td>電話番号</td><td><%= @public.phone_number %></td>
-      </tr>
-
-      <tr>
-      <td>メールアドレス</td><td><%= @public.email %></td>
-      </tr>
+      <tr><td>メールアドレス</td><td><%= @public.email %></td></tr>
 
       <tr><td>
         会員ステータス
         </td><td>
-        <% if @public.is_deleted %>
-        退会
+        <% if @public.is_deleted %><%# is_deletedの情報を取得して退会済みかチェック %>
+        退会  <%# true(退会済み)の時の表示 %>
         <% else %>
-        有効
+        有効  <%# false(初期値)の時の表示 %>
         <% end %>
-      </td>
-      </tr>
+      </td></tr>
+      <tr><td><%= link_to '編集する', edit_admin_customer_path(@public.id) %></td><td>注文履歴一覧を見る（未実装）</td></tr>
     </tbody>
   </table>
-  編集する（未実装）
-  注文履歴一覧を見る（未実装）
+

--- a/app/views/admin/genres/edit.html.erb
+++ b/app/views/admin/genres/edit.html.erb
@@ -1,2 +1,21 @@
 <h1>Admin::Genres#edit</h1>
 <p>Find me in app/views/admin/genres/edit.html.erb</p>
+
+<div class="container takasa">
+  <div class="row">
+
+    <div class="col-xs-9">
+      <h2>ジャンル編集</h2><br>
+
+       <%= form_for @genre, url: admin_genre_path(@genre.id) do |f| %>
+        <div class="field row">
+          <lavel>ジャンル</lavel>
+          <%= f.text_field :name %>
+
+          <label><%= f.radio_button :valid_invalid_status, "有効" %> 有効 </label>
+          <label><%= f.radio_button :valid_invalid_status, "無効" %> 無効</label>
+          <%= f.submit "変更を保存する", class: "btn btn-primary" %>
+         </div>
+      <% end %>
+  </div>
+</div>

--- a/app/views/admin/genres/index.html.erb
+++ b/app/views/admin/genres/index.html.erb
@@ -1,9 +1,6 @@
 <h1>Admin::Genres#index</h1>
 <p>Find me in app/views/admin/genres/index.html.erb</p>
 
-<h1>Admin::Customers#index</h1>
-<p>Find me in app/views/admin/customers/index.html.erb</p>
-
 <div class="container takasa ">
   <div class="row ">
 

--- a/app/views/admin/homes/top.html.erb
+++ b/app/views/admin/homes/top.html.erb
@@ -1,2 +1,51 @@
 <h1>Admin::Homes#top</h1>
 <p>Find me in app/views/admin/homes/top.html.erb</p>
+
+<table>
+    <thead>
+      <tr><b>注文履歴一覧</b>
+        <th>購入日時</th>
+        <th>購入者</th>
+        <th>注文個数</th>
+        <th>注文ステータス</th>
+        <th colspan="5"></th><br>
+      </tr>
+    </thead>
+      <% @orders.each do |order| %> <%# ここでordersとそれに関連するモデルの情報を取得して一覧を表示 %>
+
+        <%# １：Ｎの関係になっているモデル情報を表示するなら、この場合だとorder_detailsに紐づけられた、
+        ただ一つのorder_idの情報も探しておかないと、どのordere_detailsの情報を表示するか決めることができません %>
+        <% order.order_details.each do |order_details| %> <%# ここでも@ordersからデータを貰います %>
+    <tbody>
+      <tr>
+      <td><%= order.created_at.to_s(:datetime_jp) %>  <%# 注文idごとの登録日時をtime_formats.rbで指定した方式で表示 %></td>
+
+      <td>
+        <%# Ｎ：１の関係の場合は、Ｎであるorderが決まれば自動的に表示するpublicは１つに決められます。 %>
+        <%= order.public.family_name+order.public.first_name %>
+      </td>
+
+      <td><%= order_details.quantity %></td><%# 全てのorder_detailsのorder.idのカラム情報が必ず必要です %>
+
+      <td>
+      <% if order.status == 0 %> <%# 注文idごとの受注ステータスを表示 %>
+      入金待ち
+      <% elsif order.status == 1 %>
+      入金確認
+      <% elsif order.status == 2 %>
+      制作中
+      <% elsif order.status == 3 %>
+      発送準備中
+      <% elsif order.status == 4 %>
+      発送済み
+      <% else %>
+      Errer!  <%# なんらかのトラブルで、想定していない値になってしまったことが分かるように、このように設定しました。 %>
+      <% end %>
+      </td>
+      <td><%#= order.status %>　<%# 注文idごとの受注ステータスを表示 %></td>
+
+      </tr>
+        <% end %>
+      <% end %>
+    </tbody>
+  </table>

--- a/app/views/admin/orders/show.html.erb
+++ b/app/views/admin/orders/show.html.erb
@@ -1,2 +1,4 @@
 <h1>Admin::Orders#show</h1>
 <p>Find me in app/views/admin/orders/show.html.erb</p>
+
+

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,18 +11,17 @@
   </head>
 
   <body>
+
     <header>
       <% if public_signed_in? %>
       <li>準備中だよ。ここにpublic_userがログインした時のヘッダーを設定するんだよ。</li>
       <% elsif admin_signed_in? %>
-      <li><%= link_to "LOGO", admin_root_path %></li>
-      <li>商品一覧</li>
+      <li><%= link_to "商品一覧", admin_items_path %></li>
       <li><%= link_to "会員一覧", admin_customers_path %></li>
-      <li>注文履歴一覧</li>
-      <li>ジャンル一覧</li>
+      <li><%= link_to "注文履歴一覧", admin_root_path %></li>
+      <li><%= link_to "ジャンル一覧", admin_genres_path %></li>
       <li><%= link_to "ログアウト", destroy_admin_session_path, method: :delete %></li>
       <% else %>
-      <li><%= link_to "LOGO", root_path %></li>
       <li>About</li>
       <li>商品一覧</li>
       <li>新規登録</li>
@@ -30,6 +29,9 @@
       <% end %>
 
     </header>
+    <% flash.each do |key, value| %>
+    <%= content_tag(:div, value, class: "#{key}") %>
+  　<% end %>
     <%= yield %>
     </body>
 </html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,5 +18,6 @@ module NaganoCake
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,1 @@
+Time::DATE_FORMATS[:datetime_jp] = '%Y/%m/%d %H:%M:%S'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ end
     root to: 'homes#top'
     resources :customers, only: [:index, :show, :edit, :update]
     resources :genres, only: [:index, :edit, :create, :update]
-    resources :items, only: [:index, :show, :edit, :create, :update, :destroy]
+    resources :items, except:[:new]
 
   end
 

--- a/db/migrate/20220619093046_create_items.rb
+++ b/db/migrate/20220619093046_create_items.rb
@@ -5,7 +5,7 @@ class CreateItems < ActiveRecord::Migration[6.1]
       t.string  :name
       t.text    :explanation
       t.integer :price
-      t.boolean :is_stock
+      t.boolean :is_stock, default: "ture"
 
       t.timestamps
     end

--- a/db/migrate/20220619093335_create_cart_items.rb
+++ b/db/migrate/20220619093335_create_cart_items.rb
@@ -2,7 +2,7 @@ class CreateCartItems < ActiveRecord::Migration[6.1]
   def change
     create_table :cart_items do |t|
       t.integer :item_id
-      t.integer :user_id
+      t.integer :public_id
       t.integer :quantity
 
       t.timestamps

--- a/db/migrate/20220619093658_create_addresses.rb
+++ b/db/migrate/20220619093658_create_addresses.rb
@@ -1,7 +1,7 @@
 class CreateAddresses < ActiveRecord::Migration[6.1]
   def change
     create_table :addresses do |t|
-      t.integer :user_id
+      t.integer :public_id
       t.string  :postal_code
       t.text    :address
       t.string  :name

--- a/db/migrate/20220619094038_create_order_details.rb
+++ b/db/migrate/20220619094038_create_order_details.rb
@@ -5,7 +5,7 @@ class CreateOrderDetails < ActiveRecord::Migration[6.1]
       t.integer :order_id
       t.integer :quantity
       t.integer :price
-      t.integer :making_status
+      t.integer :making_status, default: "0"
 
       t.timestamps
     end

--- a/db/migrate/20220619094241_create_orders.rb
+++ b/db/migrate/20220619094241_create_orders.rb
@@ -1,12 +1,12 @@
 class CreateOrders < ActiveRecord::Migration[6.1]
   def change
     create_table :orders do |t|
-      t.integer :user_id
+      t.integer :public_id
       t.string  :postal_code
       t.text    :delivery_address
       t.string  :delivery_name
-      t.integer :method_of_payment
-      t.integer :status
+      t.integer :method_of_payment, default: "0"
+      t.integer :status,            default: "0"
       t.integer :total_price
       t.integer :delivery_charge
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -41,7 +41,7 @@ ActiveRecord::Schema.define(version: 2022_06_19_095056) do
   end
 
   create_table "addresses", force: :cascade do |t|
-    t.integer "user_id"
+    t.integer "public_id"
     t.string "postal_code"
     t.text "address"
     t.string "name"
@@ -63,7 +63,7 @@ ActiveRecord::Schema.define(version: 2022_06_19_095056) do
 
   create_table "cart_items", force: :cascade do |t|
     t.integer "item_id"
-    t.integer "user_id"
+    t.integer "public_id"
     t.integer "quantity"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 2022_06_19_095056) do
     t.string "name"
     t.text "explanation"
     t.integer "price"
-    t.boolean "is_stock"
+    t.boolean "is_stock", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
@@ -90,24 +90,23 @@ ActiveRecord::Schema.define(version: 2022_06_19_095056) do
     t.integer "order_id"
     t.integer "quantity"
     t.integer "price"
-    t.integer "making_status"
+    t.integer "making_status", default: 0
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "orders", force: :cascade do |t|
-    t.integer "user_id"
+    t.integer "public_id"
     t.string "postal_code"
     t.text "delivery_address"
     t.string "delivery_name"
-    t.integer "method_of_payment"
-    t.integer "status"
+    t.integer "method_of_payment", default: 0
+    t.integer "status", default: 0
     t.integer "total_price"
     t.integer "delivery_charge"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
-
 
   create_table "publics", force: :cascade do |t|
     t.datetime "created_at", precision: 6, null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,9 +1,11 @@
-Admin.create!(
+  Admin.create!(
+  id: '1',
   email: 'admin@admin',
   password: '202020',
   )
 
-Public.create!(
+  Public.create!(
+  id: '1',
   email: 'public@public',
   password: '123456',
   family_name: '齊道',
@@ -17,6 +19,7 @@ Public.create!(
   )
 
   Public.create!(
+  id: '2',
   email: 'michael@michael',
   password: '999999',
   family_name: 'パスワード忘れ',
@@ -30,6 +33,7 @@ Public.create!(
   )
 
   Public.create!(
+  id: '3',
   email: 'nagano@cake',
   password: '000000',
   family_name: 'ながの',
@@ -42,6 +46,85 @@ Public.create!(
   is_deleted: 'true',
   )
 
+  Order.create!(
+  id: '1',
+  public_id: '1',
+  postal_code: '6527485',
+  delivery_address: '兵庫県神戸市',
+  delivery_name: '齊道',
+  method_of_payment: '0',
+  status: '2',
+  total_price: '3000',
+  delivery_charge: '800',
+  )
+
+  Order.create!(
+  id: '2',
+  public_id: '2',
+  postal_code: '8888888',
+  delivery_address: 'マイケル星ダブルマインランド',
+  delivery_name: 'マイケル',
+  method_of_payment: '1',
+  status: '0',
+  total_price: '3900',
+  delivery_charge: '800',
+  )
+
+  OrderDetail.create!(
+  id: '1',
+  item_id: '1',
+  order_id: '1',
+  quantity: '1',
+  price: '3000',
+  making_status: '2',
+  )
+
+  OrderDetail.create!(
+  id: '2',
+  item_id: '1',
+  order_id: '2',
+  quantity: '1',
+  price: '3000',
+  making_status: '0',
+  )
+
+  OrderDetail.create!(
+  id: '3',
+  item_id: '2',
+  order_id: '2',
+  quantity: '3',
+  price: '900',
+  making_status: '0',
+  )
+
+  Item.create!(
+  id: '1',
+  genre_id: '1',
+  name: 'spcake1',
+  explanation: '期間限定のスペシャルケーキ',
+  price: '3000',
+  is_stock: 'ture'
+  )
+
+  Item.create!(
+  id: '2',
+  genre_id: '2',
+  name: '甘くておいしいチョコクッキー',
+  explanation: '当店のイチオシです',
+  price: '300',
+  is_stock: 'ture'
+  )
+
+
+  Genre.create!(
+  id: '1',
+  name: "ケーキ"
+  )
+
+  Genre.create!(
+  id: '2',
+  name: "クッキー"
+  )
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 #


### PR DESCRIPTION
’admin_root_path’のページに注文一覧機能を追加しました。(orderのshow,updateはまだです。)
admin側のヘッダーのリンクを設定しました。
customersのeditとupdateの機能を追加しました。
モデルにバリデーションとアソシエーションの設定を追加しました。
（バリデーションに引っかかった際のエラーメッセージ実装はまだです。）
タイムゾーンをTokyoに設定しました。
時刻表示を見本のレイアウトに近づけるよう、time_formats.rbを追加しました。
（使用方法はこのサイトを参考 https://qiita.com/tomo_k09/items/e4f19947d35890500492）
テスト用データ（seeds.rb)にデータを追加しました。